### PR TITLE
Added code of conduct draft based on Geek Feminism Wiki template.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 # EQuS Workshop on Python for Quantum Information Science #
+
+The EQuS Workshop on Python for Quantum Information Science is dedicated to a harassment-free workshop experience for everyone. Our anti-harassment policy can be found
+[here](code-of-conduct.md).
+
 **November 17 & 18, 2016** (tentative)
 
 Two-day workshop as an introduction to Python for scientific computing.

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,0 +1,56 @@
+*This code of conduct is based on the public domain template policy provided by
+the [Geek Feminism Wiki](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy).*
+
+The EQuS Workshop on Python for Quantum Information Science (EPQIS) is
+dedicated to providing a harassment-free workshop experience for everyone,
+regardless of gender, gender identity and expression, sexual orientation,
+disability, physical appearance, body size, race, age or religion. We do not
+tolerate harassment of workshop participants in any form. Sexual language and
+imagery is not appropriate for any workshop venue, including talks. Workshop
+participants violating these rules may be sanctioned or expelled from the
+workshop at the discretion of the workshop organizers.
+
+Harassment includes, but is not limited to:
+
+- Verbal comments that reinforce social structures of domination related to
+  gender, gender identity and expression, sexual orientation, disability,
+  physical appearance, body size, race, age, religion.
+- Sexual images in public spaces
+- Deliberate intimidation, stalking, or following 
+- Harassing photography or recording
+- Sustained disruption of talks or other events
+- Inappropriate physical contact
+- Unwelcome sexual attention
+- Advocating for, or encouraging, any of the above behaviour 
+
+Participants asked to stop any harassing behavior are expected to comply immediately.
+
+If a participant engages in harassing behaviour, event organisers retain the
+right to take any actions to keep the workshop a welcoming environment for all
+participants. This includes warning the offender or expulsion from the
+workshop.
+
+Workshop organisers may take action to redress anything designed to, or with
+the clear impact of, disrupting the event or making the environment hostile
+for any participants.
+
+We expect participants to follow these rules at all event venues and event-
+related social activities. We think people should follow these rules outside
+event activities too!
+
+If someone makes you or anyone else feel unsafe or unwelcome, please report it
+as soon as possible. Harassment and other code of conduct violations reduce
+the value of our event for everyone. We want you to be happy at our event.
+People like you make our event a better place.
+
+You can make a personal report by contacting a workshop organizer.
+
+When taking a personal report, we will ensure you are safe and cannot be
+overheard. They may involve other event staff to ensure your report is managed
+properly. Once safe, we'll ask you to tell us about what happened. This can be
+upsetting, but we'll handle it as respectfully as possible, and you can bring
+someone to support you. You won't be asked to confront anyone and we won't
+tell anyone who you are.
+
+Our team will be happy to help you to feel safe for the duration of the event.
+We value your attendance.


### PR DESCRIPTION
As with any professional event, I think it is critical to adopt a reasonable code of conduct. There's a few good ones out there we can adapt to our purposes, such the [Geek Feminism template](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy).

Notably, Software Carpentry has adopted a [variant of the GF code](http://software-carpentry.org/conduct/) that extends nondiscrimination to "choice of text editor," which I would suggest that we do _not_ adopt. While I appreciate the humor, harassment is an extremely serious concern in physics, and I don't recommend taking it lightly.

As a positive suggestion, then, this PR adapts the long-form Geek Feminism code of conduct template and links to it from the main README.md page.
